### PR TITLE
chore: improve connected message

### DIFF
--- a/class-resend-admin.php
+++ b/class-resend-admin.php
@@ -90,8 +90,8 @@ class Resend_Admin {
 				'resendAjax',
 				array(
 					'resend_url' => self::get_page_url(),
-					'ajax_url' => admin_url( 'admin-ajax.php' ),
-					'nonce'    => wp_create_nonce( self::NONCE ),
+					'ajax_url'   => admin_url( 'admin-ajax.php' ),
+					'nonce'      => wp_create_nonce( self::NONCE ),
 				)
 			);
 		}
@@ -125,7 +125,19 @@ class Resend_Admin {
 	}
 
 	public static function display_configuration_page() {
-		Resend::view( 'config' );
+		$status = $_GET['status'];
+		$args   = array();
+
+		if ( 'connected' === $status ) {
+			$args = array(
+				'notice' => array(
+					'message' => self::json_status( 'connected' )['message'],
+					'success' => true,
+				),
+			);
+		}
+
+		Resend::view( 'config', $args );
 	}
 
 	/**
@@ -135,7 +147,7 @@ class Resend_Admin {
 	 * @param null|string $message
 	 * @return void
 	 */
-	public static function add_status( $type = 'resend-error', $message ) {
+	public static function add_status( $type, $message ) {
 		self::$status = array(
 			'type'    => $type,
 			'message' => $message,
@@ -177,6 +189,9 @@ class Resend_Admin {
 		$message = '';
 
 		switch ( $type ) {
+			case 'connected':
+				$message = __( 'Resend is now connected to your site.', 'resend' );
+				break;
 			case 'not-allowed':
 				$message = __( 'You are not allowed to perform this action!', 'resend' );
 				break;

--- a/public/resend-admin.js
+++ b/public/resend-admin.js
@@ -1,15 +1,7 @@
 jQuery(function ($) {
-	var resendPageUrl = new URL(window.location.href);
-
-	if (
-		resendPageUrl.searchParams.has("status") &&
-		resendPageUrl.searchParams.get("status") == "connected"
-	) {
-		var response = {
-			success: true,
-			data: { message: "Resend is now connected to your site." },
-		};
-		displayAlert(response);
+	var $resendAlerts = $("#resend_alerts");
+	if ($resendAlerts.data("message") && $resendAlerts.data("success")) {
+		displayAlert($resendAlerts.data("message"), $resendAlerts.data("success"));
 	}
 
 	function setButtonLoading($button, loadingText) {
@@ -20,11 +12,11 @@ jQuery(function ($) {
 		$button.prop("disabled", false);
 	}
 
-	function displayAlert(response) {
-		var message = response.data?.message || "Unknown response";
-		var alertClass = response.success ? "is-success" : "is-danger";
+	function displayAlert(message = "Unknown response", success = true) {
+		var message = message || "Unknown response";
+		var alertClass = success ? "is-success" : "is-danger";
 
-		var $alertIcon = response.success
+		var $alertIcon = success
 			? $(
 					`<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z" /></svg>`
 			  )
@@ -40,8 +32,7 @@ jQuery(function ($) {
 		`);
 
 		$alert.find(".resend-alert-icon").html($alertIcon);
-
-		$("#resend_alerts").html($alert);
+		$resendAlerts.html($alert);
 	}
 
 	$("#resend-api-key-form").on("submit", function (e) {
@@ -61,7 +52,7 @@ jQuery(function ($) {
 				if (type === "new-key-valid") {
 					window.location.href = resendAjax.resend_url + "&status=connected";
 				} else {
-					displayAlert(response);
+					displayAlert(response.data?.message, response.success);
 					resetButton($button);
 				}
 			}
@@ -81,7 +72,7 @@ jQuery(function ($) {
 				email: $form.find("#test_email").val(),
 			},
 			function (response) {
-				displayAlert(response);
+				displayAlert(response.data?.message, response.success);
 			}
 		).always(function () {
 			resetButton($button);

--- a/views/config.php
+++ b/views/config.php
@@ -1,12 +1,19 @@
 <?php
 $current_user       = wp_get_current_user();
 $current_user_email = $current_user->user_email;
+
+$notice_message    = isset( $notice ) && isset( $notice['message'] ) ? $notice['message'] : null;
+$notice_is_success = isset( $notice ) && isset( $notice['success'] ) ? $notice['success'] : false;
 ?>
 <div class="resend-plugin-container">
 	<div class="resend-config-container">
 		<?php Resend::view( 'logo', array( 'dashboard' => true ) ); ?>
 
-		<div id="resend_alerts"></div>
+		<?php if ( isset( $notice_message ) ) : ?>
+			<div id="resend_alerts" data-message="<?php echo esc_attr( $notice_message ); ?>" data-success="<?php echo esc_attr( $notice_is_success ); ?>"></div>
+		<?php else : ?>
+			<div id="resend_alerts"></div>
+		<?php endif; ?>
 
 		<div class="resend-card-list">
 			<section class="resend-card">


### PR DESCRIPTION
This PR moves the "Connected" message from the JS file to the Resend_Admin class to ensure that there is a single source for all messages within the Wordpress Admin.

This approach allows us to automatically trigger a notification from the backend by passing the following payload to the view:

```php
$args = [
  // ...
  'notice' => [
    'message' => 'Your message here',
    'success' => true, // `true` for success theme. `false` for danger theme
  ]
  // ...
];