### PR TITLE
feat: add uninstall hook for plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.0.0] - 2024
+## [1.1.0] - July 31, 2026
+
+### Added
+
+- Uninstall handler (via `register_uninstall_hook`) to remove Resend WordPress Plugin's stored options (`resend_api_key`, `resend_from_name`, `resend_from_address`) when the plugin is deleted ([#11](https://github.com/resend/resend-wordpress/issues/11))
+
+## [1.0.0] - July 26, 2026
 
 ### Added
 - Initial release of Resend WordPress Plugin

--- a/class-resend.php
+++ b/class-resend.php
@@ -63,6 +63,36 @@ class Resend {
 	}
 
 	/**
+	 * Handle plugin uninstall tasks.
+	 *
+	 * @return void
+	 */
+	public static function plugin_uninstall() {
+		if ( is_multisite() ) {
+			$site_ids = get_sites( array( 'fields' => 'ids' ) );
+
+			foreach ( $site_ids as $site_id ) {
+				switch_to_blog( $site_id );
+				self::delete_plugin_data();
+				restore_current_blog();
+			}
+		} else {
+			self::delete_plugin_data();
+		}
+	}
+
+	/**
+	 * Delete all Resend plugin options for the current site.
+	 *
+	 * @return void
+	 */
+	private static function delete_plugin_data() {
+		delete_option( 'resend_api_key' );
+		delete_option( 'resend_from_name' );
+		delete_option( 'resend_from_address' );
+	}
+
+	/**
 	 * Retrieve the stored Resend API key.
 	 *
 	 * @return string|null The stored API key or null when not set.

--- a/readme.txt
+++ b/readme.txt
@@ -109,6 +109,10 @@ The plugin works with WordPress multisite, but each site will need its own Resen
 
 When you deactivate the plugin, WordPress will revert to its default email sending behavior. Any emails queued in Resend will still be sent normally.
 
+= What happens to my data if I delete the plugin? =
+
+When you delete the plugin from the Plugins page, your Resend settings (API key, sender name, sender email) are removed from the database. Simply deactivating the plugin does not remove this data.
+
 = Does this support attachments? =
 
 Yes, if the Resend API supports it. The plugin uses the standard `wp_mail()` function which supports attachments.
@@ -118,6 +122,9 @@ Yes, if the Resend API supports it. The plugin uses the standard `wp_mail()` fun
 Yes! You can set a custom sender email and name in the plugin settings page.
 
 == Changelog ==
+
+= 1.1.0 =
+* Plugin data is now removed on uninstall
 
 = 1.0.0 =
 * Initial release
@@ -136,6 +143,7 @@ Yes! You can set a custom sender email and name in the plugin settings page.
 == Support ==
 
 For support, feature requests, or bug reports, please visit:
+
 * [GitHub Issues](https://github.com/resend/resend-wordpress/issues)
 * [Resend Support](https://resend.com/help)
 

--- a/resend.php
+++ b/resend.php
@@ -46,6 +46,7 @@ if ( function_exists( 'wp_mail' ) ) {
 
 register_activation_hook( __FILE__, array( 'Resend', 'plugin_activation' ) );
 register_deactivation_hook( __FILE__, array( 'Resend', 'plugin_deactivation' ) );
+register_uninstall_hook( __FILE__, array( 'Resend', 'plugin_uninstall' ) );
 
 require_once RESEND__PLUGIN_DIR . 'class-resend.php';
 


### PR DESCRIPTION
## Description

This PR registers an uninstall hook for the plugin to delete the API key and additional data used by the plugin.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update

## Related Issues

Fixes #11
