### PR TITLE
Preserve Reply-To, Cc, Bcc and custom headers in the API payload

### DIFF
--- a/wp-mail.php
+++ b/wp-mail.php
@@ -198,7 +198,9 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
 				)
 			)
 		);
-		Resend_Admin::add_status( 'resend-error', $error_body );
+		if ( class_exists( 'Resend_Admin' ) ) {
+			Resend_Admin::add_status( 'resend-error', $error_body );
+		}
 		return false;
 	}
 

--- a/wp-mail.php
+++ b/wp-mail.php
@@ -10,6 +10,20 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
+ * Split an address header into the array of addresses the API expects.
+ *
+ * Callers of wp_mail() may pass several addresses in one header, comma
+ * separated, as `Cc: a@example.com, b@example.com`. Entries may be a bare
+ * address or the `Name <email>` form, both of which the API accepts as-is.
+ *
+ * @param string $content Header value.
+ * @return string[]
+ */
+function resend_address_list( $content ) {
+	return array_values( array_filter( array_map( 'trim', explode( ',', (string) $content ) ) ) );
+}
+
+/**
  * WP Mail
  *
  * @param string|string[] $to          Array or comma-separated list of email addresses to send message.
@@ -40,6 +54,9 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
 	$api_key = Resend::get_api_key();
 
 	$content_type = 'text/plain';
+	$reply_to     = array();
+	$cc           = array();
+	$bcc          = array();
 
 	if ( empty( $headers ) ) {
 		$headers = array();
@@ -73,6 +90,13 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
 						}
 						break;
 					case 'reply-to':
+						$reply_to = array_merge( $reply_to, resend_address_list( $content ) );
+						break;
+					case 'cc':
+						$cc = array_merge( $cc, resend_address_list( $content ) );
+						break;
+					case 'bcc':
+						$bcc = array_merge( $bcc, resend_address_list( $content ) );
 						break;
 					default:
 						// Add it to our grand headers array.
@@ -106,6 +130,24 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
 		'text'    => 'text/plain' === $content_type ? $message : null,
 	);
 
+	if ( ! empty( $reply_to ) ) {
+		$body['reply_to'] = $reply_to;
+	}
+
+	if ( ! empty( $cc ) ) {
+		$body['cc'] = $cc;
+	}
+
+	if ( ! empty( $bcc ) ) {
+		$body['bcc'] = $bcc;
+	}
+
+	// Anything the switch above did not recognise is a custom header the caller
+	// asked for, so pass it through rather than collecting it and dropping it.
+	if ( ! empty( $headers ) ) {
+		$body['headers'] = $headers;
+	}
+
 	foreach ( $attachments as $attachment ) {
 		if ( is_readable( $attachment ) ) {
 			$body['attachments'][] = array(
@@ -128,8 +170,35 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
 	$response = wp_remote_post( 'https://api.resend.com/emails', $args );
 
 	if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
-		do_action( 'wp_mail_failed', new WP_Error( 'wp_mail_failed' ) );
-		Resend_Admin::add_status( 'resend-error', json_decode( wp_remote_retrieve_body( $response ), true ) );
+		$error_body = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		// Core passes wp_mail_failed a WP_Error carrying the reason and the mail
+		// data, and listeners log both. An empty WP_Error reduces every failure to
+		// an indistinguishable blank line: "Domain is not verified" reads very
+		// differently from a timeout.
+		if ( is_wp_error( $response ) ) {
+			$reason = $response->get_error_message();
+		} elseif ( ! empty( $error_body['message'] ) ) {
+			$reason = $error_body['message'];
+		} else {
+			$reason = 'HTTP ' . wp_remote_retrieve_response_code( $response );
+		}
+
+		do_action(
+			'wp_mail_failed',
+			new WP_Error(
+				'wp_mail_failed',
+				$reason,
+				array(
+					'to'          => $body['to'],
+					'subject'     => $subject,
+					'message'     => $message,
+					'headers'     => $headers,
+					'attachments' => $attachments,
+				)
+			)
+		);
+		Resend_Admin::add_status( 'resend-error', $error_body );
 		return false;
 	}
 


### PR DESCRIPTION
Fixes #31.

`wp_mail()` parses `Reply-To`, `Cc`, `Bcc` and custom headers and then never adds
them to the request body, so none of them reach the API. A reply to a message
sent with `Reply-To` goes to the From address instead. Separately, a failed send
fires `wp_mail_failed` with an empty `WP_Error`, so a listener logging failures
cannot tell an unverified domain from a timeout.

## What changed

All in `wp-mail.php`, one theme: the header loop was collecting things and the
body builder was not sending them.

| Before | After |
|---|---|
| `case 'reply-to': break;` | collected into `$body['reply_to']` |
| `Cc`/`Bcc` fell to `default:`, into `$headers`, never sent | `$body['cc']` / `$body['bcc']` |
| `$headers` built (L79) but never added to `$body` | `$body['headers']` |
| `new WP_Error( 'wp_mail_failed' )` — empty | carries the API's message and core's mail data shape |

A small `resend_address_list()` helper splits comma-separated address headers
(`Cc: a@example.com, Name <b@example.com>`), since a single header may carry
several. Both bare addresses and the `Name <email>` form pass through untouched,
which the API accepts.

The failure reason is already being decoded one line below for
`Resend_Admin::add_status()`, so this reuses that decode rather than adding a
second one, and falls back to the `WP_Error` message on a transport error and to
`HTTP <code>` when the body has no message.

## What deliberately did not change

A `From:` header is still ignored — From continues to come from the plugin
settings, with `wp_mail_from` / `wp_mail_from_name` applied on top exactly as
before. Core does honour a `From:` header, so that is arguably a second bug, but
it is a behaviour change for existing installs and does not belong in the same
patch. Happy to open it separately if you want it.

Keys are only added to `$body` when the caller actually supplied them, so the
payload for an ordinary send with no extra headers is byte-identical to today.

## Verification

Against the live API, not a mock: send through the plugin, then `GET /emails/{id}`
to read back what was actually recorded (domains redacted).

Before:

```
payload keys: from, to, subject, html, text
stored:       reply_to: null   cc: null   bcc: null
failure:      reason ""        data[to] null
```

After:

```
payload keys: from, to, subject, html, text, reply_to, cc, bcc, headers
stored:       reply_to: ["replies@example.com"]
              cc: ["cc@example.com"]   bcc: ["bcc@example.com"]   status: delivered
failure:      reason "The <domain> domain is not verified. Please, add and verify
                      your domain on https://resend.com/domains"
              data[to] ["recipient@example.com"]
```

Also checked: no `reply_to`/`cc`/`bcc`/`headers` keys appear when the caller
passes none, and `wp_mail_from` / `wp_mail_from_name` still resolve the sender.

`composer lint` passes with no new errors or warnings. The two remaining warnings
on the `base64_encode()` / `file_get_contents()` attachment lines are pre-existing
and untouched.

I did not add tests since the repo has no test harness — glad to add one if you
would like the header handling covered.
