### PR TITLE
feat: add plugin version to user agent

### DIFF
--- a/class-resend-admin.php
+++ b/class-resend-admin.php
@@ -545,7 +545,7 @@ class Resend_Admin {
 	 * @return string Asset version string.
 	 */
 	public static function get_asset_file_version( $relative_path ) {
-		$full_path = RESEND__PLUGIN_DIR . $relative_path;
+		$full_path = RESEND_PLUGIN_DIR . $relative_path;
 
 		return RESEND_VERSION;
 	}

--- a/class-resend.php
+++ b/class-resend.php
@@ -32,7 +32,7 @@ class Resend {
 			$$key = $val;
 		}
 
-		$file = RESEND__PLUGIN_DIR . 'views/' . basename( $name ) . '.php';
+		$file = RESEND_PLUGIN_DIR . 'views/' . basename( $name ) . '.php';
 
 		if ( file_exists( $file ) ) {
 			include $file;

--- a/resend.php
+++ b/resend.php
@@ -17,6 +17,14 @@
  * Text Domain: resend
  */
 
+if ( ! defined( 'RESEND_PLUGIN_DIR' ) ) {
+	define( 'RESEND_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+}
+
+if ( ! defined( 'RESEND_VERSION' ) ) {
+	define( 'RESEND_VERSION', '1.0.0' );
+}
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
@@ -26,9 +34,6 @@ if ( ! function_exists( 'add_action' ) ) {
 	echo 'Hi there! I\'m just a plugin, not much I can do when called directly.';
 	exit;
 }
-
-define( 'RESEND_VERSION', '1.0.0' );
-define( 'RESEND__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 
 if ( function_exists( 'wp_mail' ) ) {
 	/**
@@ -47,15 +52,15 @@ if ( function_exists( 'wp_mail' ) ) {
 register_activation_hook( __FILE__, array( 'Resend', 'plugin_activation' ) );
 register_deactivation_hook( __FILE__, array( 'Resend', 'plugin_deactivation' ) );
 
-require_once RESEND__PLUGIN_DIR . 'class-resend.php';
+require_once RESEND_PLUGIN_DIR . 'class-resend.php';
 
 add_action( 'init', array( 'Resend', 'init' ) );
 
 if ( is_admin() ) {
-	require_once RESEND__PLUGIN_DIR . 'class-resend-admin.php';
+	require_once RESEND_PLUGIN_DIR . 'class-resend-admin.php';
 	add_action( 'init', array( 'Resend_Admin', 'init' ) );
 }
 
 if ( ! function_exists( 'wp_mail' ) ) {
-	include RESEND__PLUGIN_DIR . 'wp-mail.php';
+	include RESEND_PLUGIN_DIR . 'wp-mail.php';
 }

--- a/wp-mail.php
+++ b/wp-mail.php
@@ -121,7 +121,7 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
 			'Content-Type'  => 'application/json',
 			'Authorization' => 'Bearer ' . $api_key,
 		),
-		'user-agent' => 'resend-wordpress/' . get_bloginfo( 'version' ),
+		'user-agent' => sprintf( 'resend-wordpress/%s (WordPress/%s; PHP/%s)', RESEND_VERSION, get_bloginfo( 'version' ), phpversion() ),
 		'body'       => wp_json_encode( $body ),
 	);
 


### PR DESCRIPTION
This PR updates the plugin to use the `RESEND_VERSION` constant in the user-agent. This PR also renamed the `RESEND__PLUGIN_DIR` constant to `RESEND_PLUGIN_DIR`.

Example format:

`resend-wordpress/1.0.0 (WordPress/7.0.2; PHP/8.4.0)`